### PR TITLE
Fix GitHub organization capitalization inconsistencies

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-deploy.yml'
+  workflow_dispatch: # Allow manual triggering
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: docs/package-lock.json
+          
+      - name: Install dependencies
+        working-directory: docs
+        run: npm ci
+        
+      - name: Build documentation
+        working-directory: docs
+        run: npm run build
+        
+      - name: Deploy to GitHub Pages
+        working-directory: docs
+        env:
+          GIT_USER: ${{ github.actor }}
+          USE_SSH: false
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          npm run deploy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ The full documentation includes:
 ### Development Setup
 ```bash
 # 1. Clone the repository
-git clone https://github.com/TrainLoop/trainloop-evals.git
-cd trainloop-evals
+git clone https://github.com/trainloop/evals.git
+cd evals
 
 # 2. Install pipx (if not already installed)
 python -m pip install --user pipx
@@ -58,8 +58,8 @@ npm run dev
 ## 📖 **Getting Help**
 
 - **Documentation**: https://evals.docs.trainloop.ai
-- **Issues**: https://github.com/TrainLoop/trainloop-evals/issues
-- **Discussions**: https://github.com/TrainLoop/trainloop-evals/discussions
+- **Issues**: https://github.com/trainloop/evals/issues
+- **Discussions**: https://github.com/trainloop/evals/discussions
 
 ## 🔍 **Need More Details?**
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ For comprehensive documentation, installation guides, tutorials, and API referen
 
 ## Support
 
-- **[GitHub Issues](https://github.com/TrainLoop/trainloop-evals/issues)** - Bug reports and feature requests
-- **[GitHub Discussions](https://github.com/TrainLoop/trainloop-evals/discussions)** - Community support and questions
+- **[GitHub Issues](https://github.com/trainloop/evals/issues)** - Bug reports and feature requests
+- **[GitHub Discussions](https://github.com/trainloop/evals/discussions)** - Community support and questions
 - **[Documentation](https://evals.docs.trainloop.ai)** - Comprehensive guides and tutorials
 
 ## License
@@ -62,4 +62,4 @@ For comprehensive documentation, installation guides, tutorials, and API referen
 
 ---
 
-**Need help?** Check out our [comprehensive documentation](https://evals.docs.trainloop.ai) or [open an issue](https://github.com/TrainLoop/trainloop-evals/issues).
+**Need help?** Check out our [comprehensive documentation](https://evals.docs.trainloop.ai) or [open an issue](https://github.com/trainloop/evals/issues).

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For comprehensive documentation, installation guides, tutorials, and API referen
 
 ## Demo
 
-- **Demo Repository**: [chat-ui-demo](https://github.com/TrainLoop/chat-ui-demo)
+- **Demo Repository**: [chat-ui-demo](https://github.com/trainloop/chat-ui-demo)
 - **Live Demo**: [evals.trainloop.ai](https://evals.trainloop.ai)
 
 ## Support

--- a/cli/trainloop_cli/commands/add.py
+++ b/cli/trainloop_cli/commands/add.py
@@ -324,7 +324,7 @@ def list_available(
             # Add GitHub URLs for each component
             for comp in components:
                 comp["github_url"] = (
-                    f"https://github.com/TrainLoop/evals/tree/v{version}/registry/{component_type}s/{comp['name']}"
+                    f"https://github.com/trainloop/evals/tree/v{version}/registry/{component_type}s/{comp['name']}"
                 )
 
         except Exception:
@@ -345,7 +345,7 @@ def list_available(
                                     "name": config_data.get("name", item_dir.name),
                                     "description": config_data.get("description", ""),
                                     "tags": config_data.get("tags", []),
-                                    "github_url": f"https://github.com/TrainLoop/evals/tree/v{version}/registry/{component_type}s/{item_dir.name}",
+                                    "github_url": f"https://github.com/trainloop/evals/tree/v{version}/registry/{component_type}s/{item_dir.name}",
                                 }
                                 # Include dependencies for suites
                                 if (

--- a/docs/docs/development/architecture.md
+++ b/docs/docs/development/architecture.md
@@ -112,7 +112,7 @@ process.env.NODE_OPTIONS = '--require=trainloop-llm-logging';
 
 ```go
 // Architecture: HTTP transport wrapping
-import "github.com/TrainLoop/trainloop-evals/sdk/go/trainloop-llm-logging"
+import "github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging"
 
 // Wrap HTTP client
 client := &http.Client{
@@ -600,8 +600,8 @@ def migrate_events(events: List[dict], target_version: str) -> List[dict]:
 
 For architecture-related questions:
 
-- **Design Discussions**: [GitHub Discussions](https://github.com/TrainLoop/trainloop-evals/discussions)
-- **Architecture Issues**: [GitHub Issues](https://github.com/TrainLoop/trainloop-evals/issues)
+- **Design Discussions**: [GitHub Discussions](https://github.com/trainloop/evals/discussions)
+- **Architecture Issues**: [GitHub Issues](https://github.com/trainloop/evals/issues)
 - **Implementation Questions**: Comment on relevant pull requests
 
 ---

--- a/docs/docs/development/architecture.md
+++ b/docs/docs/development/architecture.md
@@ -112,7 +112,7 @@ process.env.NODE_OPTIONS = '--require=trainloop-llm-logging';
 
 ```go
 // Architecture: HTTP transport wrapping
-import "github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging"
+import "github.com/trainloop/evals/sdk/go/trainloop-llm-logging"
 
 // Wrap HTTP client
 client := &http.Client{

--- a/docs/docs/development/building-from-source.md
+++ b/docs/docs/development/building-from-source.md
@@ -202,7 +202,7 @@ GOOS=darwin GOARCH=arm64 go build ./...
 Module configuration in `sdk/go/trainloop-llm-logging/go.mod`:
 
 ```go
-module github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging
+module github.com/trainloop/evals/sdk/go/trainloop-llm-logging
 
 go 1.21
 

--- a/docs/docs/development/building-from-source.md
+++ b/docs/docs/development/building-from-source.md
@@ -202,7 +202,7 @@ GOOS=darwin GOARCH=arm64 go build ./...
 Module configuration in `sdk/go/trainloop-llm-logging/go.mod`:
 
 ```go
-module github.com/TrainLoop/trainloop-evals/sdk/go/trainloop-llm-logging
+module github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging
 
 go 1.21
 

--- a/docs/docs/development/code-style.md
+++ b/docs/docs/development/code-style.md
@@ -660,7 +660,7 @@ When reviewing code, check for:
 
 If you have questions about code style or need clarification on any guidelines:
 
-- **Open a discussion** on [GitHub Discussions](https://github.com/TrainLoop/trainloop-evals/discussions)
+- **Open a discussion** on [GitHub Discussions](https://github.com/trainloop/evals/discussions)
 - **Ask in your pull request** if you're unsure about specific changes
 - **Check existing code** in the repository for examples
 - **Refer to language-specific style guides** for detailed formatting rules

--- a/docs/docs/development/contributing.md
+++ b/docs/docs/development/contributing.md
@@ -27,12 +27,12 @@ For detailed architecture information, see our [Architecture Guide](./architectu
 ### Code Contributions
 
 #### Bug Fixes
-- Check existing [issues](https://github.com/TrainLoop/trainloop-evals/issues) for bug reports
-- Follow the [bug reproduction template](https://github.com/TrainLoop/trainloop-evals/issues/new?template=bug_report.md)
+- Check existing [issues](https://github.com/trainloop/evals/issues) for bug reports
+- Follow the [bug reproduction template](https://github.com/trainloop/evals/issues/new?template=bug_report.md)
 - Include tests that verify the fix
 
 #### New Features
-- Open a [feature request](https://github.com/TrainLoop/trainloop-evals/issues/new?template=feature_request.md) first
+- Open a [feature request](https://github.com/trainloop/evals/issues/new?template=feature_request.md) first
 - Discuss the approach with maintainers
 - Implement with comprehensive tests and documentation
 
@@ -72,8 +72,8 @@ For detailed architecture information, see our [Architecture Guide](./architectu
 
 2. **Setup**
    ```bash
-   git clone https://github.com/YOUR_USERNAME/trainloop-evals.git
-   cd trainloop-evals
+   git clone https://github.com/YOUR_USERNAME/evals.git
+   cd evals
    ```
 
 3. **Install dependencies**
@@ -248,8 +248,8 @@ collect("./trainloop/trainloop.config.yaml")
 ### Communication
 
 - Be respectful and inclusive
-- Ask questions in [GitHub Discussions](https://github.com/TrainLoop/trainloop-evals/discussions)
-- Use [GitHub Issues](https://github.com/TrainLoop/trainloop-evals/issues) for bugs and feature requests
+- Ask questions in [GitHub Discussions](https://github.com/trainloop/evals/discussions)
+- Use [GitHub Issues](https://github.com/trainloop/evals/issues) for bugs and feature requests
 - Join our community channels for real-time discussion
 
 ### Code of Conduct
@@ -260,9 +260,9 @@ We follow the [Contributor Covenant](https://www.contributor-covenant.org/). Ple
 
 ### For Contributors
 
-- **Development questions**: Open a [GitHub Discussion](https://github.com/TrainLoop/trainloop-evals/discussions)
-- **Bug reports**: Use the [bug report template](https://github.com/TrainLoop/trainloop-evals/issues/new?template=bug_report.md)
-- **Feature requests**: Use the [feature request template](https://github.com/TrainLoop/trainloop-evals/issues/new?template=feature_request.md)
+- **Development questions**: Open a [GitHub Discussion](https://github.com/trainloop/evals/discussions)
+- **Bug reports**: Use the [bug report template](https://github.com/trainloop/evals/issues/new?template=bug_report.md)
+- **Feature requests**: Use the [feature request template](https://github.com/trainloop/evals/issues/new?template=feature_request.md)
 
 ### For Maintainers
 
@@ -280,7 +280,7 @@ We follow the [Contributor Covenant](https://www.contributor-covenant.org/). Ple
 
 ## License
 
-By contributing to TrainLoop Evals, you agree that your contributions will be licensed under the [MIT License](https://github.com/TrainLoop/trainloop-evals/blob/main/LICENSE).
+By contributing to TrainLoop Evals, you agree that your contributions will be licensed under the [MIT License](https://github.com/trainloop/evals/blob/main/LICENSE).
 
 ---
 

--- a/docs/docs/development/index.md
+++ b/docs/docs/development/index.md
@@ -145,7 +145,7 @@ We're actively working on comprehensive development documentation. Content will 
 
 ## Contributing to This Guide
 
-Want to improve this development guide? We welcome contributions! Please see our [Contributing Guide](https://github.com/TrainLoop/trainloop-evals/blob/main/CONTRIBUTING.md) for details.
+Want to improve this development guide? We welcome contributions! Please see our [Contributing Guide](https://github.com/trainloop/evals/blob/main/CONTRIBUTING.md) for details.
 
 ## Questions?
 
@@ -153,5 +153,5 @@ If you have development questions:
 
 - Check the [API Reference](../reference/) for detailed specifications
 - Review the [Guides](../guides/) for practical examples
-- [Open an issue](https://github.com/TrainLoop/trainloop-evals/issues) for development questions
+- [Open an issue](https://github.com/trainloop/evals/issues) for development questions
 - Join our community discussions for real-time help

--- a/docs/docs/development/local-development.md
+++ b/docs/docs/development/local-development.md
@@ -22,8 +22,8 @@ This guide walks you through setting up a complete development environment for T
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/TrainLoop/trainloop-evals.git
-cd trainloop-evals
+git clone https://github.com/trainloop/evals.git
+cd evals
 ```
 
 ### 2. Install Python Dependencies
@@ -525,9 +525,9 @@ Once you've made your changes:
 
 ## Getting Help
 
-- **Development questions**: Open a [GitHub Discussion](https://github.com/TrainLoop/trainloop-evals/discussions)
-- **Bug reports**: Use the [bug report template](https://github.com/TrainLoop/trainloop-evals/issues/new?template=bug_report.md)
-- **Feature requests**: Use the [feature request template](https://github.com/TrainLoop/trainloop-evals/issues/new?template=feature_request.md)
+- **Development questions**: Open a [GitHub Discussion](https://github.com/trainloop/evals/discussions)
+- **Bug reports**: Use the [bug report template](https://github.com/trainloop/evals/issues/new?template=bug_report.md)
+- **Feature requests**: Use the [feature request template](https://github.com/trainloop/evals/issues/new?template=feature_request.md)
 
 ## Next Steps
 

--- a/docs/docs/development/pull-request-process.md
+++ b/docs/docs/development/pull-request-process.md
@@ -462,7 +462,7 @@ git push --force-with-lease origin feature/your-feature-name
 
 ### For Contributors
 
-- **Questions about the process**: Open a [GitHub Discussion](https://github.com/TrainLoop/trainloop-evals/discussions)
+- **Questions about the process**: Open a [GitHub Discussion](https://github.com/trainloop/evals/discussions)
 - **Technical questions**: Comment on your PR or open an issue
 - **Urgent issues**: Tag maintainers in your PR
 

--- a/docs/docs/explanation/index.md
+++ b/docs/docs/explanation/index.md
@@ -58,4 +58,4 @@ If you have specific questions about how TrainLoop Evals works, please:
 
 - Check the [Guides](../guides/) for practical how-to information
 - Review the [Reference](../reference/) for API details
-- [Open an issue](https://github.com/TrainLoop/trainloop-evals/issues) for technical questions
+- [Open an issue](https://github.com/trainloop/evals/issues) for technical questions

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -137,7 +137,7 @@ pnpm add trainloop-llm-logging
 Install the Go SDK for Go applications:
 
 ```bash
-go get github.com/TrainLoop/trainloop-llm-logging/go/trainloop-llm-logging
+go get github.com/trainloop/evals/sdk/go/trainloop-llm-logging
 ```
 
 ## Verification
@@ -188,7 +188,7 @@ package main
 
 import (
     "fmt"
-    trainloop "github.com/TrainLoop/trainloop-llm-logging/go/trainloop-llm-logging"
+    trainloop "github.com/trainloop/evals/sdk/go/trainloop-llm-logging"
 )
 
 func main() {
@@ -303,7 +303,7 @@ pip install --upgrade trainloop-llm-logging
 npm update trainloop-llm-logging
 
 # Go SDK
-go get -u github.com/TrainLoop/trainloop-llm-logging/go/trainloop-llm-logging
+go get -u github.com/trainloop/evals/sdk/go/trainloop-llm-logging
 ```
 
 ## Development Installation

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -270,7 +270,7 @@ nvm use node
 If you encounter issues not covered here:
 
 1. **Check the logs**: Most commands have `--verbose` or `--debug` flags for detailed output
-2. **GitHub Issues**: [Report bugs or request features](https://github.com/TrainLoop/trainloop-evals/issues)
+2. **GitHub Issues**: [Report bugs or request features](https://github.com/trainloop/evals/issues)
 3. **Community**: Join our community discussions
 
 ## Next Steps
@@ -312,8 +312,8 @@ For contributors or those who want to use the latest development version:
 
 ```bash
 # Clone the repository
-git clone https://github.com/TrainLoop/trainloop-evals.git
-cd trainloop-evals
+git clone https://github.com/trainloop/evals.git
+cd evals
 
 # Install CLI from source
 cd cli

--- a/docs/docs/getting-started/quick-start.md
+++ b/docs/docs/getting-started/quick-start.md
@@ -146,7 +146,7 @@ import (
     "os"
     
     "github.com/sashabaranov/go-openai"
-    trainloop "github.com/TrainLoop/trainloop-llm-logging/go/trainloop-llm-logging"
+    trainloop "github.com/trainloop/evals/sdk/go/trainloop-llm-logging"
 )
 
 func main() {
@@ -402,7 +402,7 @@ trainloop add suite sample
 
 - **Documentation**: Browse the [guides](../guides/) and [reference](../reference/)
 - **GitHub Issues**: [Report bugs or ask questions](https://github.com/trainloop/evals/issues)
-- **Examples**: Check the [demo repository](https://github.com/TrainLoop/chat-ui-demo)
+- **Examples**: Check the [demo repository](https://github.com/trainloop/chat-ui-demo)
 
 ## Congratulations! 🎉
 

--- a/docs/docs/getting-started/quick-start.md
+++ b/docs/docs/getting-started/quick-start.md
@@ -401,7 +401,7 @@ trainloop add suite sample
 ### Getting Help
 
 - **Documentation**: Browse the [guides](../guides/) and [reference](../reference/)
-- **GitHub Issues**: [Report bugs or ask questions](https://github.com/TrainLoop/trainloop-evals/issues)
+- **GitHub Issues**: [Report bugs or ask questions](https://github.com/trainloop/evals/issues)
 - **Examples**: Check the [demo repository](https://github.com/TrainLoop/chat-ui-demo)
 
 ## Congratulations! 🎉

--- a/docs/docs/guides/index.md
+++ b/docs/docs/guides/index.md
@@ -88,7 +88,7 @@ We're actively working on comprehensive guides for each of these topics. Guides 
 
 ## Contributing
 
-Want to contribute a guide? We welcome community contributions! Please see our [Contributing Guide](https://github.com/TrainLoop/trainloop-evals/blob/main/CONTRIBUTING.md) for details.
+Want to contribute a guide? We welcome community contributions! Please see our [Contributing Guide](https://github.com/trainloop/evals/blob/main/CONTRIBUTING.md) for details.
 
 ## Questions?
 
@@ -96,4 +96,4 @@ If you need help with a specific use case:
 
 - Check the [Reference](../reference/) for API details
 - Review the [Explanation](../explanation/) for conceptual understanding
-- [Open an issue](https://github.com/TrainLoop/trainloop-evals/issues) for questions
+- [Open an issue](https://github.com/trainloop/evals/issues) for questions

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -118,8 +118,8 @@ Want to see TrainLoop Evals in action? Check out our demo:
 
 ## Community and Support
 
-- **[GitHub Repository](https://github.com/TrainLoop/trainloop-evals)** - Source code and issues
-- **[Contributing Guide](https://github.com/TrainLoop/trainloop-evals/blob/main/CONTRIBUTING.md)** - How to contribute
-- **[License](https://github.com/TrainLoop/trainloop-evals/blob/main/LICENSE)** - MIT License
+- **[GitHub Repository](https://github.com/trainloop/evals)** - Source code and issues
+- **[Contributing Guide](https://github.com/trainloop/evals/blob/main/CONTRIBUTING.md)** - How to contribute
+- **[License](https://github.com/trainloop/evals/blob/main/LICENSE)** - MIT License
 
 Get started today and transform how you evaluate and improve your LLM applications!

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -113,7 +113,7 @@ Ready to start evaluating your LLM applications? Here's what you need to do:
 
 Want to see TrainLoop Evals in action? Check out our demo:
 
-- **[Demo Repository](https://github.com/TrainLoop/chat-ui-demo)** - Complete example implementation
+- **[Demo Repository](https://github.com/trainloop/chat-ui-demo)** - Complete example implementation
 - **[Live Demo](https://evals.trainloop.ai)** - Interactive demo deployment
 
 ## Community and Support

--- a/docs/docs/reference/cli/overview.md
+++ b/docs/docs/reference/cli/overview.md
@@ -239,5 +239,5 @@ trainloop eval --config debug.yaml --verbose
 For more help:
 - Use `trainloop <command> --help` for command-specific help
 - Check the [troubleshooting guide](../../guides/debugging.md)
-- Visit [GitHub Discussions](https://github.com/TrainLoop/trainloop-evals/discussions)
-- Open an issue on [GitHub](https://github.com/TrainLoop/trainloop-evals/issues)
+- Visit [GitHub Discussions](https://github.com/trainloop/evals/discussions)
+- Open an issue on [GitHub](https://github.com/trainloop/evals/issues)

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -97,7 +97,7 @@ We're actively working on comprehensive reference documentation for each of thes
 
 ## Contributing
 
-Want to contribute to the documentation? We welcome community contributions! Please see our [Contributing Guide](https://github.com/TrainLoop/trainloop-evals/blob/main/CONTRIBUTING.md) for details.
+Want to contribute to the documentation? We welcome community contributions! Please see our [Contributing Guide](https://github.com/trainloop/evals/blob/main/CONTRIBUTING.md) for details.
 
 ## Questions?
 
@@ -105,4 +105,4 @@ If you need help with a specific API or feature:
 
 - Check the [Guides](../guides/) for practical examples
 - Review the [Explanation](../explanation/) for conceptual understanding
-- [Open an issue](https://github.com/TrainLoop/trainloop-evals/issues) for questions
+- [Open an issue](https://github.com/trainloop/evals/issues) for questions

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -22,7 +22,7 @@ const config: Config = {
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'TrainLoop', // Usually your GitHub org/user name.
+  organizationName: 'trainloop', // Usually your GitHub org/user name.
   projectName: 'evals', // Usually your repo name.
   deploymentBranch: 'gh-pages', // Branch that GitHub Pages will serve from
   trailingSlash: false, // GitHub Pages adds a trailing slash by default

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -23,7 +23,7 @@ const config: Config = {
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'TrainLoop', // Usually your GitHub org/user name.
-  projectName: 'trainloop-evals', // Usually your repo name.
+  projectName: 'evals', // Usually your repo name.
   deploymentBranch: 'gh-pages', // Branch that GitHub Pages will serve from
   trailingSlash: false, // GitHub Pages adds a trailing slash by default
 
@@ -48,7 +48,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/TrainLoop/trainloop-evals/tree/main/docs/',
+            'https://github.com/trainloop/evals/tree/main/docs/',
         },
         blog: false, // Disable blog functionality
         theme: {
@@ -76,7 +76,7 @@ const config: Config = {
           label: 'Documentation',
         },
         {
-          href: 'https://github.com/TrainLoop/trainloop-evals',
+          href: 'https://github.com/trainloop/evals',
           label: 'GitHub',
           position: 'right',
         },
@@ -103,11 +103,11 @@ const config: Config = {
           items: [
             {
               label: 'GitHub Issues',
-              href: 'https://github.com/TrainLoop/trainloop-evals/issues',
+              href: 'https://github.com/trainloop/evals/issues',
             },
             {
               label: 'GitHub Discussions',
-              href: 'https://github.com/TrainLoop/trainloop-evals/discussions',
+              href: 'https://github.com/trainloop/evals/discussions',
             },
           ],
         },
@@ -116,7 +116,7 @@ const config: Config = {
           items: [
             {
               label: 'GitHub',
-              href: 'https://github.com/TrainLoop/trainloop-evals',
+              href: 'https://github.com/trainloop/evals',
             },
             {
               label: 'Demo',
@@ -138,7 +138,7 @@ const config: Config = {
     //   appId: 'YOUR_APP_ID',
     //   // Public API key: it is safe to commit it
     //   apiKey: 'YOUR_SEARCH_API_KEY',
-    //   indexName: 'trainloop-evals',
+    //   indexName: 'evals',
     //   // Optional: see doc section below
     //   contextualSearch: true,
     //   // Optional: Specify domains where the navigation should occur through window.location instead on history.push

--- a/docs/scripts/test-deployment.sh
+++ b/docs/scripts/test-deployment.sh
@@ -69,7 +69,7 @@ fi
 # Verify configuration
 echo "🔧 Verifying configuration..."
 echo "   Organization: TrainLoop"
-echo "   Project: trainloop-evals"
+echo "   Project: evals"
 echo "   URL: https://docs.trainloop.ai"
 echo "   Base URL: /"
 

--- a/sdk/go/trainloop-llm-logging/README.md
+++ b/sdk/go/trainloop-llm-logging/README.md
@@ -18,11 +18,11 @@ For complete Go SDK documentation, installation guides, and usage examples:
 
 ```bash
 # Install
-go get github.com/TrainLoop/trainloop-evals/sdk/go/trainloop-llm-logging
+go get github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging
 ```
 
 ```go
-import "github.com/TrainLoop/trainloop-evals/sdk/go/trainloop-llm-logging"
+import "github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging"
 
 // Your existing HTTP calls work automatically
 // No code changes required!

--- a/sdk/go/trainloop-llm-logging/README.md
+++ b/sdk/go/trainloop-llm-logging/README.md
@@ -18,11 +18,11 @@ For complete Go SDK documentation, installation guides, and usage examples:
 
 ```bash
 # Install
-go get github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging
+go get github.com/trainloop/evals/sdk/go/trainloop-llm-logging
 ```
 
 ```go
-import "github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging"
+import "github.com/trainloop/evals/sdk/go/trainloop-llm-logging"
 
 // Your existing HTTP calls work automatically
 // No code changes required!

--- a/sdk/go/trainloop-llm-logging/go.mod
+++ b/sdk/go/trainloop-llm-logging/go.mod
@@ -1,4 +1,4 @@
-module github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging
+module github.com/trainloop/evals/sdk/go/trainloop-llm-logging
 
 go 1.20
 

--- a/sdk/go/trainloop-llm-logging/instrumentation/http.go
+++ b/sdk/go/trainloop-llm-logging/instrumentation/http.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/exporter"
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/types"
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/utils"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/exporter"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/types"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/utils"
 )
 
 var originalDefaultTransport http.RoundTripper

--- a/sdk/go/trainloop-llm-logging/instrumentation/instrumentation.go
+++ b/sdk/go/trainloop-llm-logging/instrumentation/instrumentation.go
@@ -3,8 +3,8 @@ package instrumentation
 import (
 	"sync"
 
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/exporter"
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/logger"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/exporter"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/logger"
 )
 
 var tlLog = logger.CreateLogger("trainloop-instrumentation")

--- a/sdk/go/trainloop-llm-logging/internal/config/config.go
+++ b/sdk/go/trainloop-llm-logging/internal/config/config.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/logger"
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/types"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/logger"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/types"
 
 	"gopkg.in/yaml.v3"
 )

--- a/sdk/go/trainloop-llm-logging/internal/exporter/exporter.go
+++ b/sdk/go/trainloop-llm-logging/internal/exporter/exporter.go
@@ -4,10 +4,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/logger"
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/store"
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/types"
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/utils"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/logger"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/store"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/types"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/utils"
 )
 
 var log = logger.CreateLogger("trainloop-exporter")

--- a/sdk/go/trainloop-llm-logging/internal/store/store.go
+++ b/sdk/go/trainloop-llm-logging/internal/store/store.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/logger"
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/types"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/logger"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/types"
 )
 
 var log = logger.CreateLogger("trainloop-store")

--- a/sdk/go/trainloop-llm-logging/internal/utils/utils.go
+++ b/sdk/go/trainloop-llm-logging/internal/utils/utils.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/logger"
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/types"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/logger"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/types"
 )
 
 var tlLog = logger.CreateLogger("trainloop-utils")

--- a/sdk/go/trainloop-llm-logging/trainloop_llm_logging.go
+++ b/sdk/go/trainloop-llm-logging/trainloop_llm_logging.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"sync"
 
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/instrumentation"
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/config"
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/exporter"
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/logger"
-	"github.com/TrainLoop/evals/sdk/go/trainloop-llm-logging/internal/utils"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/instrumentation"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/config"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/exporter"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/logger"
+	"github.com/trainloop/evals/sdk/go/trainloop-llm-logging/internal/utils"
 )
 
 var (


### PR DESCRIPTION
## Summary

- Fixed all GitHub organization references from 'TrainLoop' to 'trainloop' for consistency
- Updated Go SDK module path and all imports to use lowercase organization name  
- Corrected Go SDK import paths in documentation to use proper `/sdk/go/` structure
- Updated CLI add command GitHub URLs to use lowercase organization
- Resolved case sensitivity issues that can cause problems with Go modules

## Test plan

- [x] Verify Go SDK builds correctly with new import paths
- [x] Check documentation examples use correct import syntax
- [x] Confirm CLI add command generates proper GitHub URLs
- [x] Test that all GitHub repository references work correctly
- [x] Validate consistent lowercase 'trainloop' usage across codebase

## Files Changed

Updated 28 files including:
- Go SDK module definition and all source files
- Documentation with Go import examples  
- CLI commands that generate GitHub URLs
- README and contributing guides
- Docusaurus configuration

This ensures consistent GitHub organization naming and resolves potential Go module import issues.