### PR TITLE
Add DeepWiki references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # 🤖📊 TrainLoop Evals
 
-[![DeepWiki Badge](https://deepwiki.com/badge-maker?url=https%3A%2F%2Fdeepwiki.com%2FTrainLoop%2Fevals)](https://deepwiki.com/TrainLoop/evals)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/TrainLoop/evals)
 
 TrainLoop Evals is a comprehensive LLM evaluation framework designed for developers who need simple, vendor-independent evaluation tools.
-
-[DeepWiki](https://deepwiki.com/TrainLoop/evals) lets you chat directly with this codebase rather than wading through documentation. It's the purest form of talking to your docs.
 
 ## Core Principles
 
@@ -41,6 +39,8 @@ trainloop studio
 For comprehensive documentation, installation guides, tutorials, and API reference:
 
 **👉 [evals.docs.trainloop.ai](https://evals.docs.trainloop.ai)**
+
+**👉 [DeepWiki](https://deepwiki.com/TrainLoop/evals)** - lets you chat directly with this codebase rather than wading through documentation. It's the purest form of talking to your docs.
 
 ### Quick Links
 - **[Getting Started](https://evals.docs.trainloop.ai/getting-started/installation)** - Installation and setup

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # 🤖📊 TrainLoop Evals
 
+[![DeepWiki Badge](https://deepwiki.com/badge-maker?url=https%3A%2F%2Fdeepwiki.com%2FTrainLoop%2Fevals)](https://deepwiki.com/TrainLoop/evals)
+
 TrainLoop Evals is a comprehensive LLM evaluation framework designed for developers who need simple, vendor-independent evaluation tools.
+
+[DeepWiki](https://deepwiki.com/TrainLoop/evals) lets you chat directly with this codebase rather than wading through documentation. It's the purest form of talking to your docs.
 
 ## Core Principles
 

--- a/docs/docs/development/index.md
+++ b/docs/docs/development/index.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 Use these pages to set up your local environment and understand how to contribute to TrainLoop.
 
-You can also browse our [DeepWiki](https://deepwiki.com/TrainLoop/evals) to chat directly with the codebase instead of digging through docs. It's the purest form of talking to your documentation.
+You can also browse our [DeepWiki](https://deepwiki.com/TrainLoop/evals) to chat directly with the codebase instead of digging through docs.
 
 ## Getting Started
 

--- a/docs/docs/development/index.md
+++ b/docs/docs/development/index.md
@@ -6,6 +6,8 @@ sidebar_position: 1
 
 Use these pages to set up your local environment and understand how to contribute to TrainLoop.
 
+You can also browse our [DeepWiki](https://deepwiki.com/TrainLoop/evals) to chat directly with the codebase instead of digging through docs. It's the purest form of talking to your documentation.
+
 ## Getting Started
 
 - [Local Development](./local-development.md)

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -110,7 +110,7 @@ Want to see TrainLoop Evals in action? Check out our demo:
 
 - **[GitHub Repository](https://github.com/trainloop/evals)** - Source code and issues
 - **[Contributing Guide](https://github.com/trainloop/evals/blob/main/CONTRIBUTING.md)** - How to contribute
-- **[DeepWiki](https://deepwiki.com/TrainLoop/evals)** - Chat directly with the codebase instead of reading docs. It's the purest form of talking to your documentation.
+- **[DeepWiki](https://deepwiki.com/TrainLoop/evals)** - Chat directly with the codebase instead of reading docs.
 - **[License](https://github.com/trainloop/evals/blob/main/LICENSE)** - MIT License
 
 Get started today and transform how you evaluate and improve your LLM applications!

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -110,6 +110,7 @@ Want to see TrainLoop Evals in action? Check out our demo:
 
 - **[GitHub Repository](https://github.com/trainloop/evals)** - Source code and issues
 - **[Contributing Guide](https://github.com/trainloop/evals/blob/main/CONTRIBUTING.md)** - How to contribute
+- **[DeepWiki](https://deepwiki.com/TrainLoop/evals)** - Chat directly with the codebase instead of reading docs. It's the purest form of talking to your documentation.
 - **[License](https://github.com/trainloop/evals/blob/main/LICENSE)** - MIT License
 
 Get started today and transform how you evaluate and improve your LLM applications!


### PR DESCRIPTION
## Summary
- show off the new DeepWiki in the README
- link to the DeepWiki in docs intro and development guide
- describe DeepWiki as a chat-based way to read the code

## Testing
- `poetry run flake8 .` *(fails: multiple style warnings)*
- `npm run build` *(fails: `docker` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687ad05cb2b483249afa9a7b28fdaa9c