### PR TITLE
Add trainloop upgrade command

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -28,6 +28,9 @@ trainloop eval
 
 # View results
 trainloop studio
+
+# Upgrade project
+trainloop upgrade
 ```
 
 For detailed information, visit **[docs.trainloop.ai](https://docs.trainloop.ai)**

--- a/cli/trainloop_cli/__main__.py
+++ b/cli/trainloop_cli/__main__.py
@@ -6,6 +6,7 @@ from trainloop_cli.commands.eval import eval_command as eval_cmd
 from trainloop_cli.commands.studio import studio_command as studio_cmd
 from trainloop_cli.commands.add import add_command
 from trainloop_cli.commands.benchmark import benchmark_command as benchmark_cmd
+from trainloop_cli.commands.upgrade import upgrade_command as upgrade_cmd
 
 
 @click.group(
@@ -105,6 +106,12 @@ def add(component_type, name, force, version, list_components, registry):
 def benchmark():
     """Compare evaluation results across multiple LLM providers."""
     benchmark_cmd()
+
+
+@cli.command("upgrade")
+def upgrade():
+    """Upgrade TrainLoop to the latest release and refresh project files."""
+    upgrade_cmd()
 
 
 def main():

--- a/cli/trainloop_cli/commands/__init__.py
+++ b/cli/trainloop_cli/commands/__init__.py
@@ -4,5 +4,6 @@ from .init import init_command as init_cmd
 from .eval import eval_command as eval_cmd
 from .studio import studio_command as studio_cmd
 from .add import add_command as add_cmd
+from .upgrade import upgrade_command as upgrade_cmd
 
-__all__ = ["init_cmd", "eval_cmd", "studio_cmd", "add_cmd"]
+__all__ = ["init_cmd", "eval_cmd", "studio_cmd", "add_cmd", "upgrade_cmd"]

--- a/cli/trainloop_cli/commands/upgrade.py
+++ b/cli/trainloop_cli/commands/upgrade.py
@@ -1,0 +1,69 @@
+"""TrainLoop CLI 'upgrade' command."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from importlib import metadata
+from pathlib import Path
+
+import click
+import yaml
+
+from .utils import find_root
+
+
+FILES_TO_UPDATE = ["README.md", "trainloop.config.yaml", ".gitignore", ".env.example"]
+
+
+def _recreate_venv(trainloop_dir: Path) -> None:
+    """Delete and recreate the nested .venv."""
+    venv_path = trainloop_dir / ".venv"
+    if venv_path.exists():
+        shutil.rmtree(venv_path)
+    subprocess.run([sys.executable, "-m", "venv", str(venv_path)], check=True)
+    if sys.platform == "win32":
+        pip_exe = venv_path / "Scripts" / "pip.exe"
+    else:
+        pip_exe = venv_path / "bin" / "pip"
+    subprocess.run([str(pip_exe), "install", "trainloop-cli"], check=True)
+
+
+def _update_config_version(trainloop_dir: Path, version: str) -> None:
+    """Add or update CLI version metadata in trainloop.config.yaml."""
+    config_path = trainloop_dir / "trainloop.config.yaml"
+    config = {}
+    if config_path.exists():
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f) or {}
+    config.setdefault("trainloop", {})["version"] = version
+    with open(config_path, "w", encoding="utf-8") as f:
+        yaml.dump(config, f, sort_keys=False)
+
+
+def upgrade_command() -> None:
+    """Upgrade TrainLoop project to the latest release."""
+    click.echo("Updating trainloop-cli to latest version...")
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--upgrade", "trainloop-cli"],
+        check=True,
+    )
+
+    root_path = find_root()
+    trainloop_dir = root_path / "trainloop"
+    scaffold_dir = Path(__file__).parent.parent / "scaffold" / "trainloop"
+
+    click.echo("Updating project files...")
+    for name in FILES_TO_UPDATE:
+        src = scaffold_dir / name
+        dest = trainloop_dir / name
+        if src.exists():
+            shutil.copy2(src, dest)
+
+    _recreate_venv(trainloop_dir)
+
+    version = metadata.version("trainloop-cli")
+    _update_config_version(trainloop_dir, version)
+
+    click.echo("✅ Upgrade complete!")

--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -52,6 +52,7 @@ The CLI respects these environment variables:
 | [`studio`](studio.md) | Launch the Studio UI |
 | [`add`](add.md) | Add components from the registry |
 | [`benchmark`](benchmark.md) | Compare LLM providers |
+| [`upgrade`](upgrade.md) | Upgrade project files and dependencies |
 
 ### Configuration
 
@@ -80,6 +81,9 @@ trainloop add metric accuracy
 
 # Run benchmark
 trainloop benchmark
+
+# Upgrade project
+trainloop upgrade
 ```
 
 ## Configuration Discovery

--- a/docs/docs/reference/cli/upgrade.md
+++ b/docs/docs/reference/cli/upgrade.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 9
+---
+
+# trainloop upgrade
+
+Upgrade the TrainLoop project to the latest release and refresh generated files.
+
+## Synopsis
+
+```bash
+trainloop upgrade
+```
+
+## Description
+
+The `trainloop upgrade` command pulls the newest TrainLoop CLI, updates auto-generated
+files like `README.md`, `.gitignore`, and `trainloop.config.yaml`, recreates the
+local `.venv`, and records the CLI version in your configuration.
+
+## Examples
+
+```bash
+# Upgrade the current project
+trainloop upgrade
+```


### PR DESCRIPTION
## Summary
- add `upgrade` command to the CLI
- document upgrade in README and docs
- expose upgrade from CLI module

## Testing
- `poetry run flake8 trainloop_cli/commands/upgrade.py`
- `poetry run trainloop --help`
- `python3 scripts/run_tests_simple.py`

------
https://chatgpt.com/codex/tasks/task_e_687ae9483ad08324b675fa2bfb65ae77