### PR TITLE
Add default flush_immediately config

### DIFF
--- a/cli/trainloop_cli/scaffold/trainloop/README.md
+++ b/cli/trainloop_cli/scaffold/trainloop/README.md
@@ -65,14 +65,14 @@ response = client.chat.completions.create(
 ```
 
 **Buffering Control:**
-By default, the Python SDK buffers LLM calls and flushes them every 10 seconds or when 5+ calls are buffered. For immediate flushing or manual control:
+By default, the Python SDK flushes each LLM call immediately. To enable buffering and flush manually when needed:
 
 ```python
-# Flush immediately after each LLM call (useful for testing/scripts)
-collect("some/path/to/trainloop.config.yaml", flush_immediately=True)
-
-# Or use default buffering and flush manually when needed
+# Flush immediately after each LLM call (default)
 collect("some/path/to/trainloop.config.yaml")
+
+# Or enable buffering and flush manually when needed
+collect("some/path/to/trainloop.config.yaml", flush_immediately=False)
 # ... your LLM calls ...
 flush()  # Manually flush buffered calls
 ```

--- a/cli/trainloop_cli/scaffold/trainloop/trainloop.config.yaml
+++ b/cli/trainloop_cli/scaffold/trainloop/trainloop.config.yaml
@@ -2,6 +2,7 @@
 trainloop:
   data_folder: data # Relative to this config file
   log_level: warn
+  flush_immediately: true
   # Judge Configuration
   judge:
     env_path: "../.env" # Optional: Path to a .env file to load for the judge (e.g., for API keys)

--- a/docs/docs/reference/cli/env-vars.md
+++ b/docs/docs/reference/cli/env-vars.md
@@ -86,7 +86,7 @@ trainloop eval
 
 **Values**: `true`, `false`
 
-**Default**: `false`
+**Default**: `true`
 
 **Usage**:
 ```bash

--- a/examples/go/trainloop/trainloop.config.yaml
+++ b/examples/go/trainloop/trainloop.config.yaml
@@ -1,6 +1,7 @@
 trainloop:
   data_folder: data
   log_level: warn
+  flush_immediately: true
   judge:
     env_path: ../.env
     models:

--- a/examples/python/trainloop/trainloop.config.yaml
+++ b/examples/python/trainloop/trainloop.config.yaml
@@ -1,6 +1,7 @@
 trainloop:
   data_folder: data
   log_level: warn
+  flush_immediately: true
   judge:
     env_path: ../.env
     models:

--- a/examples/typescript/trainloop/trainloop.config.yaml
+++ b/examples/typescript/trainloop/trainloop.config.yaml
@@ -1,6 +1,7 @@
 trainloop:
   data_folder: data
   log_level: warn
+  flush_immediately: true
   judge:
     env_path: ../.env
     models:

--- a/sdk/go/trainloop-llm-logging/internal/config/config.go
+++ b/sdk/go/trainloop-llm-logging/internal/config/config.go
@@ -53,8 +53,9 @@ func LoadConfigIntoEnv(trainloopConfigPathOpt string) {
 	dataFolderSet := os.Getenv("TRAINLOOP_DATA_FOLDER") != ""
 	hostAllowlistSet := os.Getenv("TRAINLOOP_HOST_ALLOWLIST") != ""
 	logLevelSet := os.Getenv("TRAINLOOP_LOG_LEVEL") != ""
+	flushImmediatelySet := os.Getenv("TRAINLOOP_FLUSH_IMMEDIATELY") != ""
 
-	if dataFolderSet && hostAllowlistSet && logLevelSet {
+	if dataFolderSet && hostAllowlistSet && logLevelSet && flushImmediatelySet {
 		log.Debug("All TrainLoop environment variables already set, skipping config file")
 		return
 	}
@@ -150,6 +151,17 @@ func LoadConfigIntoEnv(trainloopConfigPathOpt string) {
 		} else {
 			os.Setenv("TRAINLOOP_LOG_LEVEL", "WARN") // Default log level
 		}
+	}
+	if !flushImmediatelySet {
+		flushVal := "true"
+		if configData.FlushImmediately != nil {
+			if *configData.FlushImmediately {
+				flushVal = "true"
+			} else {
+				flushVal = "false"
+			}
+		}
+		os.Setenv("TRAINLOOP_FLUSH_IMMEDIATELY", flushVal)
 	}
 	logger.SetLogLevel(os.Getenv("TRAINLOOP_LOG_LEVEL")) // Re-apply log level
 }

--- a/sdk/go/trainloop-llm-logging/internal/types/types.go
+++ b/sdk/go/trainloop-llm-logging/internal/types/types.go
@@ -50,9 +50,10 @@ type LLMCallData struct {
 
 // TrainloopConfigObject represents the 'trainloop' section of the config file.
 type TrainloopConfigObject struct {
-	DataFolder    string   `yaml:"data_folder"`
-	HostAllowlist []string `yaml:"host_allowlist"`
-	LogLevel      string   `yaml:"log_level"`
+	DataFolder       string   `yaml:"data_folder"`
+	HostAllowlist    []string `yaml:"host_allowlist"`
+	LogLevel         string   `yaml:"log_level"`
+	FlushImmediately *bool    `yaml:"flush_immediately"`
 }
 
 // TrainloopConfig is the top-level structure for the config file.

--- a/sdk/go/trainloop-llm-logging/trainloop_llm_logging.go
+++ b/sdk/go/trainloop-llm-logging/trainloop_llm_logging.go
@@ -54,7 +54,12 @@ func Collect(trainloopConfigPathOpt ...string) {
 	if len(trainloopConfigPathOpt) > 0 {
 		configPath = trainloopConfigPathOpt[0]
 	}
-	config.LoadConfigIntoEnv(configPath) // Loads config and sets env vars
+       config.LoadConfigIntoEnv(configPath) // Loads config and sets env vars
+
+       flushEnv := os.Getenv("TRAINLOOP_FLUSH_IMMEDIATELY")
+       if flushEnv == "" {
+               os.Setenv("TRAINLOOP_FLUSH_IMMEDIATELY", "true")
+       }
 
 	// SDK is disabled if TRAINLOOP_DATA_FOLDER is not set.
 	dataFolder := os.Getenv("TRAINLOOP_DATA_FOLDER")

--- a/sdk/python/trainloop_llm_logging/config.py
+++ b/sdk/python/trainloop_llm_logging/config.py
@@ -69,6 +69,7 @@ def load_config_into_env(trainloop_config_path: str | None = None) -> None:
     data_folder_set = "TRAINLOOP_DATA_FOLDER" in os.environ
     host_allowlist_set = "TRAINLOOP_HOST_ALLOWLIST" in os.environ
     log_level_set = "TRAINLOOP_LOG_LEVEL" in os.environ
+    flush_immediately_set = "TRAINLOOP_FLUSH_IMMEDIATELY" in os.environ
 
     logger.debug(
         "Environment variable check - TRAINLOOP_DATA_FOLDER: %s",
@@ -83,12 +84,21 @@ def load_config_into_env(trainloop_config_path: str | None = None) -> None:
         "set" if log_level_set else "not set",
     )
     logger.debug(
+        "Environment variable check - TRAINLOOP_FLUSH_IMMEDIATELY: %s",
+        "set" if flush_immediately_set else "not set",
+    )
+    logger.debug(
         "Environment variable check - TRAINLOOP_CONFIG_PATH: %s",
         "set" if trainloop_config_path else "not set",
     )
 
     # If all variables are already set, no need to load config
-    if data_folder_set and host_allowlist_set and log_level_set:
+    if (
+        data_folder_set
+        and host_allowlist_set
+        and log_level_set
+        and flush_immediately_set
+    ):
         print(
             "[TrainLoop] All TrainLoop environment variables already set, skipping config file"
         )
@@ -184,3 +194,20 @@ def load_config_into_env(trainloop_config_path: str | None = None) -> None:
         else:
             # Use default log level if not set anywhere
             os.environ["TRAINLOOP_LOG_LEVEL"] = "WARN"
+            logger.info("Set TRAINLOOP_LOG_LEVEL to default: WARN")
+
+    if not flush_immediately_set:
+        if config_data and "flush_immediately" in config_data:
+            flush_val = str(config_data["flush_immediately"]).lower()
+        else:
+            flush_val = "true"
+        os.environ["TRAINLOOP_FLUSH_IMMEDIATELY"] = flush_val
+        logger.info(
+            "Set TRAINLOOP_FLUSH_IMMEDIATELY from config/default: %s",
+            flush_val,
+        )
+    else:
+        logger.debug(
+            "Using existing TRAINLOOP_FLUSH_IMMEDIATELY: %s",
+            os.environ["TRAINLOOP_FLUSH_IMMEDIATELY"],
+        )

--- a/sdk/python/trainloop_llm_logging/register.py
+++ b/sdk/python/trainloop_llm_logging/register.py
@@ -28,7 +28,8 @@ _EXPORTER = None
 
 
 def collect(
-    trainloop_config_path: str | None = None, flush_immediately: bool = False
+    trainloop_config_path: str | None = None,
+    flush_immediately: bool | None = None,
 ) -> None:
     """Boot-strap the TrainLoop logging SDK (idempotent).
 
@@ -58,6 +59,18 @@ def collect(
 
     print("[TrainLoop] Loading config...")
     load_config_into_env(trainloop_config_path)
+
+    env_flush = os.environ.get("TRAINLOOP_FLUSH_IMMEDIATELY")
+    if flush_immediately is None:
+        if env_flush is not None:
+            flush_immediately = env_flush.lower() == "true"
+        else:
+            flush_immediately = True
+            os.environ["TRAINLOOP_FLUSH_IMMEDIATELY"] = "true"
+    else:
+        os.environ["TRAINLOOP_FLUSH_IMMEDIATELY"] = (
+            "true" if flush_immediately else "false"
+        )
 
     if "TRAINLOOP_DATA_FOLDER" not in os.environ:
         logger_module.register_logger.warning(

--- a/sdk/python/trainloop_llm_logging/types.py
+++ b/sdk/python/trainloop_llm_logging/types.py
@@ -54,6 +54,7 @@ class TrainLoopConfigObject(TypedDict):
     data_folder: Optional[str]
     host_allowlist: Optional[List[str]]
     log_level: Optional[str]
+    flush_immediately: Optional[bool]
 
 
 class TrainloopConfig(TypedDict):

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -67,7 +67,7 @@ function checkForEarlyImports(): void {
  * 
  * @param flushImmediately - If true, flush each LLM call immediately (useful for testing)
  */
-export function collect(flushImmediately: boolean = false): void {
+export function collect(flushImmediately?: boolean): void {
   logger.debug(`collect() called with flushImmediately=${flushImmediately}`);
   
   // Check for early imports before initialization
@@ -76,6 +76,14 @@ export function collect(flushImmediately: boolean = false): void {
   // Always load the config in case the config path changed
   logger.debug("Loading config...");
   loadConfig();
+
+  if (flushImmediately === undefined) {
+    const envVal = process.env.TRAINLOOP_FLUSH_IMMEDIATELY;
+    flushImmediately = envVal ? envVal.toLowerCase() === "true" : true;
+    process.env.TRAINLOOP_FLUSH_IMMEDIATELY = flushImmediately ? "true" : "false";
+  } else {
+    process.env.TRAINLOOP_FLUSH_IMMEDIATELY = flushImmediately ? "true" : "false";
+  }
   
   if (isInitialized) {
     // If SDK is already initialized, check if this is a different configuration

--- a/sdk/typescript/src/types/shared.d.ts
+++ b/sdk/typescript/src/types/shared.d.ts
@@ -30,6 +30,7 @@ export type TrainloopConfig = {
         data_folder: string;
         host_allowlist: string[];
         log_level: string;
+        flush_immediately?: boolean;
     }
 }
 

--- a/sdk/typescript/tests/unit/config-precedence.test.ts
+++ b/sdk/typescript/tests/unit/config-precedence.test.ts
@@ -58,7 +58,7 @@ describe('Config Precedence', () => {
 
     // Should log what came from where
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Using config values for: data_folder, host_allowlist')
+      expect.stringContaining('Using config values for: data_folder, host_allowlist, flush_immediately')
     );
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining('Using environment variables for: log_level')
@@ -88,7 +88,7 @@ describe('Config Precedence', () => {
     expect(process.env.TRAINLOOP_LOG_LEVEL).toBe('INFO');
 
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Using config values for: data_folder, host_allowlist, log_level')
+      expect.stringContaining('Using config values for: data_folder, host_allowlist, log_level, flush_immediately')
     );
 
     consoleSpy.mockRestore();


### PR DESCRIPTION
## Summary
- add flush_immediately to scaffold config
- load and default flush_immediately in Python, TypeScript and Go SDKs
- set env var in Go collect
- update TypeScript tests
- update docs to mention flush_immediately default is now true

## Testing
- `python3 scripts/run_tests_simple.py`
- `poetry run ruff check sdk/python/trainloop_llm_logging`
- `npm run build` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ddef0fb4c8324a54a5f64d225384e